### PR TITLE
document install and run redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Tooling
 * Install [Rust](https://www.rust-lang.org/tools/install).
+* Install [Redis Stack](https://redis.io/docs/install/install-stack/)
 * Install [ODA API Rust SDK: TMF634](https://github.com/oda-components/oda-api-sdk-rust#tmf634)
 * Install [ODA API Rust SDK: TMF639](https://github.com/oda-components/oda-api-sdk-rust#tmf639)
 
@@ -14,6 +15,11 @@ cargo doc --workspace
 ```
 
 ## Run
+
+### Redis
+```bash
+redis-stack-server &
+```
 
 ### TMF634
 ```bash


### PR DESCRIPTION
The RIs shall use [Redis Stack](https://redis.io/docs/about/about-stack/) for persistence of _Collection_ items. It is necessary to start redis-stack-server before starting a `tmf*_server`. 