### PR TITLE
correct json encoding in create resource specification operation

### DIFF
--- a/tmf634/server/src/server.rs
+++ b/tmf634/server/src/server.rs
@@ -616,6 +616,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
                 if v.get("@type").is_none() {
                     v["@type"] = json!("ResourceSpecification");
                 }
+info!("v: {:?}", v);
                 v.to_string()
             },
             Err(result) => {
@@ -638,8 +639,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
                 return Ok(CreateResourceSpecificationResponse::BadRequest(error))
             },
         };
+info!("entity: {:?}", entity);
         let ok = String::from("OK");
-        match con.json_set(key, "$", &json).await {
+        match con.json_set(key, "$", &entity).await {
             Ok::<String, _>(result) if result.eq(&ok) => {
                 Ok(CreateResourceSpecificationResponse::Created(entity))
             },


### PR DESCRIPTION
Silly mistake, used the old variable, not the newly created one.