### PR TITLE
implement query pagination

### DIFF
--- a/tmf634/server/src/server.rs
+++ b/tmf634/server/src/server.rs
@@ -710,69 +710,69 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         let mut con = self.redis_connection.clone();
         let mut cmd = redis::cmd("FT.SEARCH");
         match cmd.arg("resourceSpecification").arg("*").query_async(&mut con).await {
-            Ok(redis::Value::Bulk(v)) => {
-                let count = match v[0] {
-                    redis::Value::Int(n) => n as i32,
-                    _ => {
+            Ok(redis::Value::Bulk(v)) if v.len() > 1 => {
+                let total = match &v[0] {
+                    redis::Value::Int(n) => *n as i32,
+                    other => {
                         let code = String::from("500");
                         let reason = String::from("Unexpected result");
                         let mut error = models::Error::new(code, reason);
-                        let message = format!("unsuccessful redis command: {:?}", v);
+                        let message = format!("unsuccessful redis command: {:?}", other);
                         error.message = Some(message);
-                        return Ok(ListResourceSpecificationResponse::InternalServerError(error))
-                    }
+                        return Ok(ListResourceSpecificationResponse::InternalServerError(error));
+                    },
                 };
                 let mut body = Vec::new();
-                let mut i: usize = 2;
-                let end: usize = (count * 2).try_into().unwrap();
-                while i <= end {
-                    let pair = match &v[i] {
-                        redis::Value::Bulk(result) => result,
-                        _ => {
+                let mut count = 0;
+                let mut i: usize = 1;
+                while i + 1 <= v.len() {
+                    match &v[i + 1] {
+                        redis::Value::Bulk(pair) if pair.len() == 2 => match &pair[1] {
+                            redis::Value::Data(buf) => {
+                                match serde_json::from_slice::<models::ResourceSpecification>(&buf) {
+                                    Ok(entity) => body.push(entity),
+                                    Err(result) => {
+                                        let code = String::from("500");
+                                        let reason = String::from("Unexpected result");
+                                        let mut error = models::Error::new(code, reason);
+                                        let message = format!("error decoding json: {:?}", result);
+                                        error.message = Some(message);
+                                        return Ok(ListResourceSpecificationResponse::InternalServerError(error));
+                                    },
+                                }
+                            },
+                            other => {
+                                let code = String::from("500");
+                                let reason = String::from("Unexpected result");
+                                let mut error = models::Error::new(code, reason);
+                                let message = format!("unsuccessful redis command: {:?}", other);
+                                error.message = Some(message);
+                                return Ok(ListResourceSpecificationResponse::InternalServerError(error));
+                            },
+                        },
+                        other => {
                             let code = String::from("500");
                             let reason = String::from("Unexpected result");
                             let mut error = models::Error::new(code, reason);
-                            let message = format!("unsuccessful redis command: {:?}", v[i]);
+                            let message = format!("unsuccessful redis command: {:?}", other);
                             error.message = Some(message);
-                            return Ok(ListResourceSpecificationResponse::InternalServerError(error))
+                            return Ok(ListResourceSpecificationResponse::InternalServerError(error));
                         },
                     };
-                    match &pair[1] {
-                        redis::Value::Data(buf) => {
-                            match serde_json::from_slice::<models::ResourceSpecification>(&buf) {
-                                Ok(entity) => body.push(entity),
-                                Err(result) => {
-                                    let code = String::from("500");
-                                    let reason = String::from("Unexpected result");
-                                    let mut error = models::Error::new(code, reason);
-                                    let message = format!("error decoding json: {:?}", result);
-                                    error.message = Some(message);
-                                    return Ok(ListResourceSpecificationResponse::InternalServerError(error))
-                                },
-                            }
-                        },
-                        _ => {
-                            let code = String::from("500");
-                            let reason = String::from("Unexpected result");
-                            let mut error = models::Error::new(code, reason);
-                            let message = format!("unsuccessful redis command: {:?}", pair[i]);
-                            error.message = Some(message);
-                            return Ok(ListResourceSpecificationResponse::InternalServerError(error))
-                        },
-                    };
+                    count += 1;
                     i += 2;
                 };
                 Ok(ListResourceSpecificationResponse::Success {
                     body: body,
-                    x_total_count: None,
+                    x_total_count: Some(total),
                     x_result_count: Some(count)
                 })
             },
-            Ok(result) => {
+            Ok(other) => {
                 let code = String::from("500");
                 let reason = String::from("Unexpected result");
                 let mut error = models::Error::new(code, reason);
-                let message = format!("unsuccessful redis command: {:?}", result);
+                let message = format!("unsuccessful redis command: {:?}", other);
                 error.message = Some(message);
                 Ok(ListResourceSpecificationResponse::InternalServerError(error))
             },


### PR DESCRIPTION
Support pagination in `list_resource_specification()` by mapping the `offset` and `limit` query parameters to the Redis [`FT.SEARCH`](https://redis.io/commands/ft.search/) optional argument `LIMIT first num`.

Retrieve the first two items:
```
$ curl -vs -H 'Accept: application/json' "http://localhost:8080/tmf-api/resourceCatalog/v4/resourceSpecification?limit=2"
...
> GET /tmf-api/resourceCatalog/v4/resourceSpecification?limit=2 HTTP/1.1
...
< HTTP/1.1 200 OK
...
< x-total-count: 59
< x-result-count: 2
...
[
     {"id":"018c0cc6-a365-71b6-b625-f349ed4b2b32",...},
     {"id":"018c0cc6-d36b-76eb-877a-dd35544047ad",...}
] 
```

Retrieve the second and third items:
```
curl -vs -H 'Accept: application/json' "http://localhost:8080/tmf-api/resourceCatalog/v4/resourceSpecification?offset=1&limit=2"
...
> GET /tmf-api/resourceCatalog/v4/resourceSpecification?offset=1&limit=2 HTTP/1.1
...
< HTTP/1.1 200 OK
...
< x-total-count: 59
< x-result-count: 2
...
[
    {"id":"018c0cc6-d36b-76eb-877a-dd35544047ad",...},
    {"id":"018c0ef7-c8b9-7d7d-9495-0baf2202d760",....}
]
````