### PR TITLE
correct json encoding in create resource specification operation

### DIFF
--- a/tmf634/server/src/server.rs
+++ b/tmf634/server/src/server.rs
@@ -637,7 +637,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
             },
         };
         let ok = String::from("OK");
-        match con.json_set(key, "$", &json).await {
+        match con.json_set(key, "$", &entity).await {
             Ok::<String, _>(result) if result.eq(&ok) => {
                 Ok(CreateResourceSpecificationResponse::Created(entity))
             },


### PR DESCRIPTION
This was submitted before in pull request #35, commit [e1545d19ca](https://github.com/oda-components/oda-api-ri-rust/commit/e1545d19ca5e5c1097fdbba05987806090935cd9), but later reverted in error.

There is no need for explicitly converting from `serde_json` as it gets automatically converted when used, and correctly!  The problem experienced here was that although the double quoted JSON was accepted in Redis, and read back correctly, the search indexing was NOT. 

Running `MONITOR` in `redis-cli` we were able to see what was being received by the Redis server.