### PR TITLE
Fix /resourceSpecification endpoint

### DIFF
--- a/tmf634/server/src/server.rs
+++ b/tmf634/server/src/server.rs
@@ -817,7 +817,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         let mut con = self.redis_connection.clone();
         match con.json_get(key, "$").await {
             Ok::<Vec<String>, _>(v) if v.len() == 1 => {
-                let entity = serde_json::from_str::<Vec<models::ResourceSpecification>>(&v[0].to_string());
+                let entity = serde_json::from_str::<Vec<models::ResourceSpecification>>(&v[0]);
                 Ok(RetrieveResourceSpecificationResponse::Success(entity.expect("Failed to retrieve specification").get(0).unwrap().clone()))
             },
             Ok::<Vec<String>, _>(v) if v.len() == 0 => {


### PR DESCRIPTION
Code `200`:
```
$ curl -vs -H 'Accept: application/json' http://localhost:8080/tmf-api/resourceCatalog/v4/resourceSpecification/018c2116-78b5-79bc-88c1-f6acb767c812 | json_pp
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /tmf-api/resourceCatalog/v4/resourceSpecification/018c2116-78b5-79bc-88c1-f6acb767c812 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: application/json
> 
< HTTP/1.1 200 OK
< x-span-id: e56d21ad-e3b8-4174-8ab9-3de03da25d7a
< content-type: application/json;charset=utf-8
< content-length: 190
< date: Thu, 30 Nov 2023 21:50:51 GMT
< 
{ [190 bytes data]
* Connection #0 to host localhost left intact
{
   "name" : "example",
   "id" : "018c2116-78b5-79bc-88c1-f6acb767c812",
   "href" : "/tmf-api/resourceCatalog/v4/resourceSpecification/018c2116-78b5-79bc-88c1-f6acb767c812",
   "@type" : "ResourceSpecification"
}
```
Code `404`:
```
$ curl -vs -H 'Accept: application/json' http://localhost:8080/tmf-api/resourceCatalog/v4/resourceSpecification/not_found | json_pp
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /tmf-api/resourceCatalog/v4/resourceSpecification/not_found HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: application/json
> 
< HTTP/1.1 404 Not Found
< x-span-id: e7262a79-ceab-4076-a1fd-07f2d61c04e9
< content-type: application/json;charset=utf-8
< content-length: 86
< date: Thu, 30 Nov 2023 21:51:01 GMT
< 
{ [86 bytes data]
* Connection #0 to host localhost left intact
{
   "reason" : "No such id exists",
   "message" : "unsuccessful redis command: []",
   "code" : "404"
}
```