### PR TITLE
TMF634 client CLI: ListResourceSpecification always has empty list in response

### DIFF
--- a/tmf634/client/src/main.rs
+++ b/tmf634/client/src/main.rs
@@ -465,7 +465,7 @@ fn main() {
         Some("ListResourceSpecification") => {
             let result = rt.block_on(client.list_resource_specification(
                   Some("fields_example".to_string()),
-                  Some(56),
+                  Some(0),
                   Some(56)
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());


### PR DESCRIPTION
Reduce to `0` the `offset` in `ListResourceSpecification` for correct getting data.